### PR TITLE
Feat yaml

### DIFF
--- a/squiRL/vpg/vpg.py
+++ b/squiRL/vpg/vpg.py
@@ -54,7 +54,7 @@ class VPG(pl.LightningModule):
 
     @staticmethod
     def add_model_specific_args(
-            parent_parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+            parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         """Adds model specific config args to parser
 
         Args:
@@ -63,7 +63,6 @@ class VPG(pl.LightningModule):
         Returns:
             argparse.ArgumentParser: Updated argument parser
         """
-        parser = ArgumentParser(parents=[parent_parser], add_help=False)
         parser.add_argument("--policy",
                             type=str,
                             default='MLP',

--- a/train.py
+++ b/train.py
@@ -36,12 +36,23 @@ group_prog = parser.add_argument_group("program_args")
 group_env = parser.add_argument_group("environment_args")
 
 # add PROGRAM level args
-group_prog.add_argument('--seed', type=int, default=42)
-group_prog.add_argument('--debug', type=bool, default=False)
-group_prog.add_argument('--algorithm', type=str, default='VPG')
+group_prog.add_argument('--seed', type=int, default=42, help="experiment seed")
+group_prog.add_argument(
+    '--debug',
+    type=bool,
+    default=False,
+    help="stops logging to wandb, turns on profiler, sets num_workers "
+    "to None, to allow debugging on a single thread")
+group_prog.add_argument('--algorithm',
+                        type=str,
+                        default='VPG',
+                        help="DRL algorithm")
 args, remaining_args = parser.parse_known_args()
 group_alg = parser.add_argument_group(args.algorithm + "_args")
-group_prog.add_argument('--project', type=str, default=args.algorithm)
+group_prog.add_argument('--project',
+                        type=str,
+                        default=args.algorithm,
+                        help="project name for wandb logs")
 
 # add environment specific args
 group_env.add_argument("--env",

--- a/train.py
+++ b/train.py
@@ -31,36 +31,45 @@ def main(hparams) -> None:
     trainer.fit(algorithm)
 
 
-parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(add_help=False)
+group_prog = parser.add_argument_group("program_args")
+group_env = parser.add_argument_group("environment_args")
 
 # add PROGRAM level args
-parser.add_argument('--seed', type=int, default=42)
-parser.add_argument('--debug', type=bool, default=False)
-parser.add_argument('--algorithm', type=str, default='VPG')
-args, _ = parser.parse_known_args()
-parser.add_argument('--project', type=str, default=args.algorithm)
+group_prog.add_argument('--seed', type=int, default=42)
+group_prog.add_argument('--debug', type=bool, default=False)
+group_prog.add_argument('--algorithm', type=str, default='VPG')
+args, remaining_args = parser.parse_known_args()
+group_alg = parser.add_argument_group(args.algorithm + "_args")
+group_prog.add_argument('--project', type=str, default=args.algorithm)
 
 # add environment specific args
-parser.add_argument("--env",
-                    type=str,
-                    default="CartPole-v0",
-                    help="gym environment tag")
-parser.add_argument("--episode_length",
-                    type=int,
-                    default=200,
-                    help="max length of an episode")
-parser.add_argument("--max_episode_reward",
-                    type=int,
-                    default=200,
-                    help="max episode reward in the environment")
+group_env.add_argument("--env",
+                       type=str,
+                       default="CartPole-v0",
+                       help="gym environment tag")
+group_env.add_argument("--episode_length",
+                       type=int,
+                       default=200,
+                       help="max length of an episode")
+group_env.add_argument("--max_episode_reward",
+                       type=int,
+                       default=200,
+                       help="max episode reward in the environment")
 
 # add algorithm specific args
-parser = squiRL.reg_algorithms[args.algorithm].add_model_specific_args(parser)
+group_alg = squiRL.reg_algorithms[args.algorithm].add_model_specific_args(
+    group_alg)
 
 # add all the available trainer options to argparse
 parser = pl.Trainer.add_argparse_args(parser)
 
+# this is done to add all args to help
+parser = argparse.ArgumentParser(parents=[parser])
+
 args = parser.parse_args()
 args, _ = parser.parse_known_args()
+
+print(args)
 
 main(args)

--- a/train.py
+++ b/train.py
@@ -76,7 +76,9 @@ group_alg = squiRL.reg_algorithms[args.algorithm].add_model_specific_args(
 parser = pl.Trainer.add_argparse_args(parser)
 
 # this is done to add all args to help
-parser = argparse.ArgumentParser(parents=[parser])
+parser = argparse.ArgumentParser(
+    parents=[parser],
+    epilog="Trainer args docs can be found at PyTorch Lightning.")
 
 args = parser.parse_args()
 args, _ = parser.parse_known_args()


### PR DESCRIPTION
I updated train.py to provide useful help messages and to print all configs on running an experiment. This is to provide the user with much needed feedback. I will not be adding in a yaml configuration pipeline. Instead, I will make sure that each model/algorithm has well defined defaults. Also, I will later add benchmarks for each algorithm anyway and wandb logs everything including architecture and hparams. Yaml at this point feels like over engineering.