### PR TITLE
Fixed double iterations per max_epochs bug. Upgrading to lightning 1.2.3 does it.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ gym==0.17.2
 gym3==0.3.3
 msgpack-numpy==0.4.3.2
 numpy==1.18.1
-pytorch-lightning==1.0.6
+pytorch-lightning==1.2.3
 pytorch_lightning-bolts==0.2.5
 pytorch-transformers==1.1.0
 torch==1.6.0

--- a/squiRL/a2c/a2c.py
+++ b/squiRL/a2c/a2c.py
@@ -39,6 +39,7 @@ class A2C(pl.LightningModule):
         """
         super(A2C, self).__init__()
         self.hparams = hparams
+        self.automatic_optimization = False
 
         self.env = gym3.vectorize_gym(num=self.hparams.num_envs,
                                       env_kwargs={"id": self.hparams.env})
@@ -68,10 +69,6 @@ class A2C(pl.LightningModule):
                             type=str,
                             default='MLP',
                             help="NN policy used by agent")
-        parser.add_argument("--custom_optimizers",
-                            type=bool,
-                            default=True,
-                            help="this value must not be changed")
         parser.add_argument("--lr_critic",
                             type=float,
                             default=0.001,
@@ -122,7 +119,7 @@ class A2C(pl.LightningModule):
                                   dim=-1).squeeze(0)[range(len(actions)),
                                                      actions]
 
-        discounted_rewards = reward_to_go(rewards, states, self.gamma)
+        discounted_rewards = reward_to_go(rewards, self.gamma)
         discounted_rewards = torch.tensor(discounted_rewards).float()
         advantage = discounted_rewards - values
         advantage = advantage.type_as(log_probs)

--- a/squiRL/common/utils.py
+++ b/squiRL/common/utils.py
@@ -20,8 +20,7 @@ def collate_episodes(batch):
     return batch_dict.values()
 
 
-def reward_to_go(rewards: torch.Tensor, states: torch.Tensor,
-                 gamma: float) -> torch.tensor:
+def reward_to_go(rewards: torch.Tensor, gamma: float) -> torch.tensor:
     """Calculates reward to go over an entire episode
 
     Args:

--- a/squiRL/ppo/ppo.py
+++ b/squiRL/ppo/ppo.py
@@ -186,7 +186,7 @@ class PPO(pl.LightningModule):
             actor_loss += ac_loss
             critic_loss += cr_loss
 
-        self.manual_backward(cr_loss)
+        self.manual_backward(cr_loss, critic_optimizer)
         critic_optimizer.step()
         critic_optimizer.zero_grad()
 

--- a/squiRL/ppo/ppo.py
+++ b/squiRL/ppo/ppo.py
@@ -39,6 +39,7 @@ class PPO(pl.LightningModule):
         """
         super(PPO, self).__init__()
         self.hparams = hparams
+        self.automatic_optimization = False
 
         self.env = gym3.vectorize_gym(num=self.hparams.num_envs,
                                       env_kwargs={"id": self.hparams.env})
@@ -129,7 +130,7 @@ class PPO(pl.LightningModule):
         log_probs = F.log_softmax(action_logits,
                                   dim=-1).squeeze(0)[range(len(actions)),
                                                      actions]
-        discounted_rewards = reward_to_go(rewards, states, self.gamma)
+        discounted_rewards = reward_to_go(rewards, self.gamma)
         discounted_rewards = torch.tensor(discounted_rewards).float()
         advantage = discounted_rewards - values
         advantage = advantage.type_as(log_probs)
@@ -185,7 +186,7 @@ class PPO(pl.LightningModule):
             actor_loss += ac_loss
             critic_loss += cr_loss
 
-        self.manual_backward(cr_loss, critic_optimizer)
+        self.manual_backward(cr_loss)
         critic_optimizer.step()
         critic_optimizer.zero_grad()
 

--- a/squiRL/vpg/vpg.py
+++ b/squiRL/vpg/vpg.py
@@ -113,7 +113,7 @@ class VPG(pl.LightningModule):
                                   dim=-1).squeeze(0)[range(len(actions)),
                                                      actions]
 
-        discounted_rewards = reward_to_go(rewards)
+        discounted_rewards = reward_to_go(rewards, self.gamma)
         discounted_rewards = torch.tensor(discounted_rewards)
         advantage = (discounted_rewards - discounted_rewards.mean()) / (
             discounted_rewards.std() + self.eps)

--- a/train.py
+++ b/train.py
@@ -30,27 +30,24 @@ def train(hparams) -> None:
         hparams.logger = WandbLogger(project=hparams.project)
         hparams.logger.experiment
         profiler = None
-
-    cwd = os.getcwd()
-    path = os.path.join(cwd, 'models')
-    if not os.path.exists(path):
-        os.mkdir(path)
-    path = os.path.join(path, hparams.logger.version)
-    if not os.path.exists(path):
-        os.mkdir(path)
-    path = os.path.join(path, hparams.logger.version)
-    if hparams.save_config:
-        with open(path + '.json', 'wt') as f:
-            config = vars(hparams).copy()
-            config.pop("logger")
-            config.pop("gpus")
-            config.pop("tpu_cores")
-            json.dump(config, f, indent=4)
+        cwd = os.getcwd()
+        path = os.path.join(cwd, 'models')
+        if not os.path.exists(path):
+            os.mkdir(path)
+        path = os.path.join(path, hparams.logger.version)
+        if not os.path.exists(path):
+            os.mkdir(path)
+        path = os.path.join(path, hparams.logger.version)
+        if hparams.save_config:
+            with open(path + '.json', 'wt') as f:
+                config = vars(hparams).copy()
+                config.pop("logger")
+                config.pop("gpus")
+                config.pop("tpu_cores")
+                json.dump(config, f, indent=4)
 
     seed_everything(hparams.seed)
     algorithm = squiRL.reg_algorithms[hparams.algorithm](hparams)
-    if args.custom_optimizers:
-        args.automatic_optimization = False
     trainer = pl.Trainer.from_argparse_args(hparams, profiler=profiler)
     trainer.fit(algorithm)
 


### PR DESCRIPTION
Upgraded to lightning==1.2.3 to solve the double iterations issue. now the train script runs for exactly max_epochs times. i had to modify other scripts to account for the new lightning version, specifically in anything that had to do with manual optimization. cleaned a couple of bugs.